### PR TITLE
Apply border-box css to fix padding issue

### DIFF
--- a/examples/demo/src/App.css
+++ b/examples/demo/src/App.css
@@ -4,6 +4,7 @@
 }
 
 * {
+  box-sizing: border-box;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
Applied `box-sizing: border-box;` to fix padding issue in details toolbar.

Before:
<img width="1020" alt="screen shot 2018-02-26 at 1 03 29 pm" src="https://user-images.githubusercontent.com/195992/36692565-afeec894-1af5-11e8-9a3e-d9e5b07e11da.png">

After:
<img width="1007" alt="screen shot 2018-02-26 at 1 03 37 pm" src="https://user-images.githubusercontent.com/195992/36692570-b3fa9300-1af5-11e8-9f7f-69d3eecef5f9.png">
