### PR TITLE
Reducing bundle size and GC churn

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "popmotion": "^8.1.10",
     "prop-types": "^15.6.0",
     "raf": "^3.4.0",
-    "react": "^16.2.0"
+    "react": "^16.2.0",
+    "stylefire": "^1.1.9"
   },
   "peerDependencies": {},
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -2,15 +2,13 @@ import React, { Component } from 'react';
 import propTypes from 'prop-types';
 import keyframe from 'keyframe';
 import raf from 'raf';
-import {
-  css,
-  easing,
-  keyframes,
-  spring,
-  tween,
-  value,
-  transform,
-} from 'popmotion';
+import css from 'stylefire/css';
+import easing from 'popmotion/easing';
+import keyframes from 'popmotion/animations/keyframes';
+import spring from 'popmotion/animations/spring';
+import tween from 'popmotion/animations/tween';
+import value from 'popmotion/reactions/value';
+import transform from 'popmotion/transformers';
 import { interpolateObject } from './util';
 
 const { pipe } = transform;
@@ -53,15 +51,15 @@ const fadeOutTween = ({ element, options = {} }) =>
     if (v === 1) node.style.pointerEvents = 'all';
   });
 
-const fadeInTween = ({ element, options = {} }) =>
-  keyframes({
+const fadeInTween = ({ element, options = {} }) => {
+  const styler = css(element);
+  return keyframes({
     values: [{ opacity: 0 }, { opacity: 1 }],
     easings: easing.linear,
     times: [0.8, 1],
     ...options,
   })
     .start(style => {
-      const styler = css(element);
       const node = element;
 
       styler.set(style);
@@ -69,6 +67,7 @@ const fadeInTween = ({ element, options = {} }) =>
       if (style.opacity === 1) node.style.pointerEvents = 'all';
     })
     .pause();
+};
 
 const hideTween = ({ element }) => ({
   seek: pipe(Math.round, t => {


### PR DESCRIPTION
I've imported the Popmotion functions individually - it's a little less tidy but it ditches all the unnecessary stuff and will save 3-4kb. 

Also I moved a styler creation call to outside an update function, there's an optimisation (unpublished) in stylefire that would mitigate this but for now firing this every frame will eat a fair amount of memory. 