### PR TITLE
Fix text overflowing from details-toolbar

### DIFF
--- a/examples/demo/src/App.css
+++ b/examples/demo/src/App.css
@@ -151,6 +151,7 @@ p {
   width: 100%;
   padding: 1rem;
   z-index: 3;
+  box-sizing: border-box;
 }
 
 .details-content-placeholder {


### PR DESCRIPTION
In the expanded view, in big resolutions, the coordinates on the top right side are overflowing the box-model they are in.